### PR TITLE
feat: Add initialPage and onPageChange handlers

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, {PropTypes} from 'react'
 import {render} from 'react-dom'
 import Slider from '../src'

--- a/demo/index.js
+++ b/demo/index.js
@@ -279,6 +279,7 @@ const App = props => {
       <Slider factor={0.5}
               slides={pages.length}
               children={renderPages}
+              onPageChange={page => console.log(`Page changed to ${page}.`)}
               anchors='!/intro'/>
       <div className={styles.main}>
         <h2>Create impressive scroll aware webpages</h2>

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ class OverScroll extends Component {
     super(props)
     this.state = {
       scrollY: window.scrollY,
-      counter: Math.min(Math.max(props.initialPage, 0), props.slides && props.slides.length - 1),
+      counter: Math.min(Math.max(props.initialPage, 0), props.slides - 1),
       scrollOffset: 0
     }
     this.updateScroll = this.updateScroll.bind(this)
@@ -59,7 +59,9 @@ class OverScroll extends Component {
 
   componentWillReceiveProps (nextProps) {
     if (this.props.initialPage !== nextProps.initialPage) {
-      this.setState({ counter: nextProps.initialPage })
+      this.setState({
+        counter: Math.min(Math.max(nextProps.initialPage, 0), nextProps.slides - 1)
+      })
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,12 @@ class OverScroll extends Component {
     }
   }
 
+  componentWillReceiveProps (nextProps) {
+    if (this.props.initialPage !== nextProps.initialPage) {
+      this.setState({ counter: nextProps.initialPage })
+    }
+  }
+
   /**
    * checks for the current position and translates the scroll to index and percent
    * @param  {Number} scrollY - window.scrollY

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ class OverScroll extends Component {
    * a scroll based slideshow with wings
    * @param {Object} props
    * @param {String} props.className
+   * @param {Number} props.initialPage - the index of the initial page to show
+   * @param {Function} props.onPageChange - triggered when a page is changed
    * @param {render} props.children - render function for children
    * @param {string} props.anchors - allow navigation via pagers
    *                                 (`anchors='!/works'` will create a url hashbang `#!/works/[1,2,3...]``)
@@ -21,7 +23,7 @@ class OverScroll extends Component {
     super(props)
     this.state = {
       scrollY: window.scrollY,
-      counter: 0,
+      counter: Math.min(Math.max(props.initialPage, 0), props.slides && props.slides.length - 1),
       scrollOffset: 0
     }
     this.updateScroll = this.updateScroll.bind(this)
@@ -40,13 +42,18 @@ class OverScroll extends Component {
       children: PropTypes.func.isRequired,
       anchors: PropTypes.string,
       slides: PropTypes.number.isRequired,
-      factor: PropTypes.number.isRequired
+      factor: PropTypes.number.isRequired,
+      initialPage: PropTypes.number,
+      onPageChange: PropTypes.func
     }
   }
 
+  // TODO: React 16 doesn't pick these up?
   static defaultProps () {
     return {
-      factor: 1
+      factor: 1,
+      initialPage: 0,
+      onPageChange: function () {}
     }
   }
 
@@ -80,6 +87,11 @@ class OverScroll extends Component {
       counter = this.props.slides - 1
       scrollOffset = 100
     }
+
+    if (this.state.counter !== counter) {
+      this.props.onPageChange && this.props.onPageChange(counter)
+    }
+
     this.setState({
       scrollY,
       fixed,

--- a/src/spec/index.js
+++ b/src/spec/index.js
@@ -20,4 +20,23 @@ describe('<OverScroll />', () => {
     wrapper.setProps({ className: 'changed' })
     expect(wrapper.props().className).toEqual('changed')
   })
+  it('allows to pass initial page', () => {
+    const initialPage = 1
+    const render = (page) => <div className={`page-${page}`} />
+    const wrapper = mount(<OverScroll children={render} factor={1} initialPage={initialPage} slides={[0, 1, 2]} />)
+    expect(wrapper.contains(<div className={`page-${initialPage}`}/>)).toEqual(true)
+  })
+  it('clamps initial page to zero', () => {
+    const initialPage = -1
+    const render = (page) => <div className={`page-${page}`} />
+    const wrapper = mount(<OverScroll children={render} factor={1} initialPage={initialPage} slides={[0, 1, 2]} />)
+    expect(wrapper.contains(<div className={`page-0`}/>)).toEqual(true)
+  })
+  it('clamps initial page to maximum', () => {
+    const initialPage = 10
+    const render = (page) => <div className={`page-${page}`} />
+    const wrapper = mount(<OverScroll children={render} factor={1} initialPage={initialPage} slides={[0, 1, 2]} />)
+    expect(wrapper.contains(<div className={`page-2`}/>)).toEqual(true)
+  })
+  // TODO: Trigger onPageChange and test it
 })

--- a/src/spec/index.js
+++ b/src/spec/index.js
@@ -23,19 +23,19 @@ describe('<OverScroll />', () => {
   it('allows to pass initial page', () => {
     const initialPage = 1
     const render = (page) => <div className={`page-${page}`} />
-    const wrapper = mount(<OverScroll children={render} factor={1} initialPage={initialPage} slides={[0, 1, 2]} />)
+    const wrapper = mount(<OverScroll children={render} factor={1} initialPage={initialPage} slides={3} />)
     expect(wrapper.contains(<div className={`page-${initialPage}`}/>)).toEqual(true)
   })
   it('clamps initial page to zero', () => {
     const initialPage = -1
     const render = (page) => <div className={`page-${page}`} />
-    const wrapper = mount(<OverScroll children={render} factor={1} initialPage={initialPage} slides={[0, 1, 2]} />)
+    const wrapper = mount(<OverScroll children={render} factor={1} initialPage={initialPage} slides={3} />)
     expect(wrapper.contains(<div className={`page-0`}/>)).toEqual(true)
   })
   it('clamps initial page to maximum', () => {
     const initialPage = 10
     const render = (page) => <div className={`page-${page}`} />
-    const wrapper = mount(<OverScroll children={render} factor={1} initialPage={initialPage} slides={[0, 1, 2]} />)
+    const wrapper = mount(<OverScroll children={render} factor={1} initialPage={initialPage} slides={3} />)
     expect(wrapper.contains(<div className={`page-2`}/>)).toEqual(true)
   })
   // TODO: Trigger onPageChange and test it


### PR DESCRIPTION
This is more of a proof of concept with initial tests. More can be added and the feature can be documented more fully if this is the right direction.

These handlers are important for third party integration (updating hash while scrolling, setting initial state). Likely we should update page if the prop changes too (needs additional React lifecycle method).

It looks like default props aren't being picked up (React 16?) so that's something that should be fixed in another PR.